### PR TITLE
Fixed numbering issue

### DIFF
--- a/client/debugger.md
+++ b/client/debugger.md
@@ -7,21 +7,16 @@ description: How to use ManiaPlanet debugger
 # ManiaPlanet debugger
 
 1. To start the debugger, press `Ctrl + F7`
-
 You will have an histogram in the middle of the screen, and a little window in the top left corner:
-
 ![Debugger](./img/debug1.jpg)
 
 2. When you have a micro freeze, you will have a sightly higher bar, clic on `Paused: False` to freeze the histogram.
- 
 (Press `Alt` to unlock the mouse in game)
 
 3. When the histogram is stopped, click on the highest bar to show the detail:
-
 ![Debugger](./img/debug2.jpg)
 
 4. You can click on a second bar to get a comparison:
-
 ![Debugger](./img/debug3.jpg)
 
 5. Press `F10` and go to `MyDocument\ManiaPlanet\ScreenShots` folder to get the screenshot.


### PR DESCRIPTION
Bug of the documentation editor / display?
If there are too many blank lines, new paragraphs are added, which break the numbering. Apparently the editor does not see this.
