### PR TITLE
Downgrade jekyll-sitemap to 0.6.1 to pass CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'jekyll-sitemap'
+gem 'jekyll-sitemap', '0.6.1'


### PR DESCRIPTION
Travis has been failing ever since 0.6.3 was used.