### PR TITLE
Added TAB to Map Editor shortcuts and key hints

### DIFF
--- a/client/shortcuts.md
+++ b/client/shortcuts.md
@@ -109,6 +109,7 @@ tags: client
 * Space (or Left mouse button): places selected block type at the cursor position
 * Right Ctrl (or Right mouse button) : rotates block selection
 * Left Ctrl : Record or Playback Editors input replay (on New Map selection)
+* TAB : hide / show block selection menus
 
 ### Terraforming
 


### PR DESCRIPTION
It would be good if the wiki could be updated accordingly, or add a link to the wiki to this page