### PR TITLE
Update keyserver URL

### DIFF
--- a/04.dedicated-server/06.references/08.apt-repository/docs.md
+++ b/04.dedicated-server/06.references/08.apt-repository/docs.md
@@ -15,7 +15,7 @@ Add this to your APT source configuration, in `/etc/apt/sources.list.d/maniaplan
 
 Load our GPG key:
 
-	 sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 00AD7462840A6C13
+	 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 00AD7462840A6C13
      
 Update:
 


### PR DESCRIPTION
Seems that for some newer systems keys.gnupg.net does not work, however keyserver.ubuntu.com will.